### PR TITLE
add argument to set zero fill setting

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -87,6 +87,7 @@ static struct argp_option options[] = {
   { "listing-file", 'L', "<file.lst>", 0, "Name of the listing file" },
   { "warnings", 'W', 0, 0, "Show overflow warnings" },
   { "output", 'o', "<file.nes>", 0, "Name of the output file, use '-' for stdout" },
+  { "zero-fill", 'z', 0, 0, "Fill unused space in ROM with zeroes" },
   { 0 }
 };
 
@@ -159,12 +160,17 @@ parse_opt (int key, char *arg, struct argp_state *state)
         argp_usage(state);
       break;
     case 's':
+      if (zero_fill==1) break;
       dump_seg++;
       if (dump_seg > 2) dump_seg = 2;
       break;
     case 'S':
+      if (zero_fill==1) break;
       dump_seg = 2;
       break;
+    case 'z':
+      zero_fill=1;
+      dump_seg = 0; // disable segment info as zero filling makes it inaccurate
     case 'i':
       list_opt = 1;
       break;

--- a/source/main.c
+++ b/source/main.c
@@ -160,17 +160,14 @@ parse_opt (int key, char *arg, struct argp_state *state)
         argp_usage(state);
       break;
     case 's':
-      if (zero_fill==1) break;
       dump_seg++;
       if (dump_seg > 2) dump_seg = 2;
       break;
     case 'S':
-      if (zero_fill==1) break;
       dump_seg = 2;
       break;
     case 'z':
       zero_fill=1;
-      dump_seg = 0; // disable segment info as zero filling makes it inaccurate
     case 'i':
       list_opt = 1;
       break;
@@ -267,6 +264,8 @@ main(int argc, char **argv)
 
   /* parse command line */
   argp_parse(&argp, argc, argv, 0, 0, 0);
+
+  if (zero_fill==1) dump_seg = 0; // disable segment info as zero filling makes it inaccurate
 
   /* search file extension */
   char basename[strlen(in_fname)+1];


### PR DESCRIPTION
This allows to produce the same ROM from a disassembled .asm file by forcing the empty space to be 0.

I use this as part of my NES disassembler project which verifies the produced .asm file be reassembling it using the chosen assembler: https://github.com/retroenv/nesgodisasm